### PR TITLE
Fix build with clamav 1.0.0

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -120,7 +120,7 @@ qDebug() << "engine lock requested, stopping dispose timer";
 			path = QDir::toNativeSeparators(settings()->databasePath()).toLocal8Bit();
 		}
 
-		int ret = cl_load(path.data(), m_scanEngine, &sigs, CL_DB_STDOPT); // NOLINT(hicpp-signed-bitwise)
+		cl_error_t ret = cl_load(path.data(), m_scanEngine, &sigs, CL_DB_STDOPT); // NOLINT(hicpp-signed-bitwise)
 
 		if(CL_SUCCESS != ret) {
 			qDebug() << "failed to load databases:" << cl_strerror(ret);


### PR DESCRIPTION
src/application.cpp: In member function ‘cl_engine* Qlam::Application::acquireEngine()’: src/application.cpp:126:80: error: invalid conversion from ‘int’ to ‘cl_error_t’ [-fpermissive]

Reason: https://github.com/Cisco-Talos/clamav/commit/0d13177ada297c1d4ce8c06a4ed83cfbe8308acd